### PR TITLE
Add lock icon for authenticated API endpoints

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -75,3 +75,20 @@
   content: "patch";
   background-color: var(--openapi-code-orange);
 }
+
+/* Show lock icon in heading for authenticated endpoints */
+article:has(.openapi-security__details) .openapi__heading::after {
+  content: "";
+  display: inline-block;
+  width: 20px;
+  height: 20px;
+  margin-left: 8px;
+  vertical-align: middle;
+  background-color: var(--ifm-color-primary);
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='currentColor'%3E%3Cpath d='M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2zm-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1 1.71 0 3.1 1.39 3.1 3.1v2z'/%3E%3C/svg%3E");
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='currentColor'%3E%3Cpath d='M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2zm-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1 1.71 0 3.1 1.39 3.1 3.1v2z'/%3E%3C/svg%3E");
+  -webkit-mask-size: contain;
+  mask-size: contain;
+  -webkit-mask-repeat: no-repeat;
+  mask-repeat: no-repeat;
+}


### PR DESCRIPTION
## Summary

- Add visual lock icon indicator for API endpoints that require authentication
- Icon appears after the endpoint heading (e.g., `/api/v1/balance 🔒`)
- Uses CSS `:has()` selector to detect presence of security requirements
- SVG icon rendered in primary theme color, works in light/dark modes

## Preview

**Authenticated endpoint:**
```
/api/v1/balance 🔒
```

**Public endpoint:**
```
/api/gateway/ping
```

## Test plan

- [x] Run `yarn start` and navigate to `/api/v1/balance` - should show lock icon
- [x] Navigate to `/api/gateway/ping` - should NOT show lock icon
- [x] Verify icon displays correctly in both light and dark modes

Created by [Claude Code](https://claude.com/claude-code)